### PR TITLE
Group Chat Buttons Fix

### DIFF
--- a/css/theme.css
+++ b/css/theme.css
@@ -1762,7 +1762,7 @@ div.guild.active {
     transform: translate(0px)!important;
     background: #191919!important
 }
-[class*="messagesWrapper_"] {
+[class*="chatContent_"] {
     z-index: 1!important;
 }
 .app {


### PR DESCRIPTION
The `messagesWrapper` class includes everything except the text box, so a small portion of the text box was behind something else and was un-clickable. The `chatContent` class is the parent which includes the text box, so now the whole panel is at the correct z index.